### PR TITLE
Fix where extraction to work for ISO dates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,10 +38,10 @@ const extractWhere = ({ query, basedProperties, symbolic }) => {
       let [comparisonOp, value] = properties[property].split(':');
       if (comparisonOp in operators) {
         let result = operators[comparisonOp](symbolic, value);
-        whereClause[property] = { [result.comparisonOp]: result.value };
+        whereClause[property] = { [result.comparisonOp]: result.value === 'null' ? null : result.value };
       }
     } else {
-      whereClause[property] = properties[property];
+      whereClause[property] = properties[property] === 'null' ? null : properties[property];
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,8 @@ const extractWhere = ({ query, basedProperties, symbolic }) => {
   let whereClause = {};
   for (let property in properties) {
     if (properties[property].includes(':')) {
-      let [comparisonOp, value] = properties[property].split(':');
+      let index = properties[property].indexOf(':');
+      let [comparisonOp, value] = [properties[property].slice(0, index), properties[property].slice(index + 1)];
       if (comparisonOp in operators) {
         let result = operators[comparisonOp](symbolic, value);
         whereClause[property] = { [result.comparisonOp]: result.value === 'null' ? null : result.value };


### PR DESCRIPTION
Currently a between statement with 2 iso dates  http://www.example.com/players?createdAt=between:2020-05-03T15:48:18.000Z,2020-05-05T09:19:56.000Z

was producing the following
```
query: [ 'between', '2020-05-03T15' ]
sql: WHERE createdAt BETWEEN '2020-05-03 12:00:00' AND NULL
```

It now produces the following:
```
query: [ 'between', '2020-05-04T15:48:18.000Z,2020-05-05T09:19:56.000Z' ]
sql: WHERE createdAt BETWEEN '2020-05-04 15:48:18' AND '2020-05-05 09:19:56'
```