### PR TITLE
Treating nullable values on 'or' and 'and' operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 package-lock.json
+yarn.lock
 
 coverage.*
 

--- a/lib/operators.js
+++ b/lib/operators.js
@@ -186,15 +186,25 @@ const operators = {
     }
   },
   and: (symbolic, value) => {
+    let parsedValue = value.split(',');
+    if(parsedValue.includes('null')){
+      parsedValue = parsedValue.filter(att => att !== 'null')
+      parsedValue.push(null);
+    }
     return {
       comparisonOp: symbolic ? Symbol.for('and') : '$and',
-      value: value.split(',')
+      value: parsedValue
     }
   },
   or: (symbolic, value) => {
+    let parsedValue = value.split(',');
+    if(parsedValue.includes('null')){
+      parsedValue = parsedValue.filter(att => att !== 'null')
+      parsedValue.push(null);
+    }
     return {
       comparisonOp: symbolic ? Symbol.for('or') : '$or',
-      value: value.split(',')
+      value: parsedValue
     }
   },
 };


### PR DESCRIPTION
As default if the user is looking for camps that is null it will fail because it is passing the parameter as a string instead of null itself, this pull request is to fix this on 'and' and 'or' operators.